### PR TITLE
Normalize API hashtag filters

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -11,6 +11,24 @@ from .db import close_pool, ensure_schema, open_pool
 from .queries import fetch_user_stats
 
 
+def normalize_hashtags(hashtag: list[str] | None) -> list[str] | None:
+    if not hashtag:
+        return None
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in hashtag:
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        cleaned = "#" + cleaned.lstrip("#")
+        key = cleaned.lower()
+        if key not in seen:
+            normalized.append(cleaned)
+            seen.add(key)
+    return normalized or None
+
+
 @asynccontextmanager
 async def lifespan(app: Litestar):
     await open_pool()
@@ -37,12 +55,13 @@ async def get_user_stats(
     if start >= end:
         raise HTTPException(status_code=400, detail="start must be before end")
 
-    users = await fetch_user_stats(start=start, end=end, hashtag=hashtag, limit=limit, offset=offset)
+    normalized_hashtag = normalize_hashtags(hashtag)
+    users = await fetch_user_stats(start=start, end=end, hashtag=normalized_hashtag, limit=limit, offset=offset)
     return {
         "count": len(users),
         "start": start.isoformat(),
         "end": end.isoformat(),
-        "hashtag": hashtag,
+        "hashtag": normalized_hashtag,
         "limit": limit,
         "offset": offset,
         "users": users,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@ from litestar import Litestar
 from litestar.testing import TestClient
 
 from api import app as api_app
-from api.app import get_user_stats, health
+from api.app import get_user_stats, health, normalize_hashtags
 from api.pg_schema import PG_SCHEMA as API_PG_SCHEMA
 from osmsg.pg_schema import PG_SCHEMA as CLI_PG_SCHEMA
 
@@ -30,6 +30,18 @@ def test_health_endpoint_returns_ok():
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_normalize_hashtags_accepts_bare_or_prefixed_values():
+    assert normalize_hashtags(["maproulette", "#HOTOSM", "  #roads  ", ""]) == [
+        "#maproulette",
+        "#HOTOSM",
+        "#roads",
+    ]
+
+
+def test_normalize_hashtags_dedupes_case_insensitively():
+    assert normalize_hashtags(["maproulette", "#MapRoulette", "#roads"]) == ["#maproulette", "#roads"]
 
 
 def test_user_stats_endpoint_returns_expected_response(monkeypatch):
@@ -69,7 +81,7 @@ def test_user_stats_endpoint_returns_expected_response(monkeypatch):
             params=[
                 ("start", "2026-05-01T00:00:00Z"),
                 ("end", "2026-05-02T00:00:00Z"),
-                ("hashtag", "#mapathon"),
+                ("hashtag", "mapathon"),
                 ("hashtag", "#roads"),
                 ("limit", "1"),
             ],


### PR DESCRIPTION
## Summary

Fixes hashtag query handling in the Litestar API.

The API now normalizes hashtag query values before querying Postgres, so clients can pass either bare or prefixed hashtags.

Examples accepted:

- `hashtag=maproulette`
- `hashtag=#maproulette`
- repeated values like `hashtag=maproulette&hashtag=#roads`

## Changes

- Normalize hashtag filters in `api/app.py`
- Trim empty hashtag values
- Deduplicate repeated hashtag values case-insensitively
- Add tests for normalized hashtag behavior

## Tests

```bash
uv run --group api pytest tests/test_api.py
uv run --group api ruff check api tests/test_api.py

@kshitijrajsharma dai can you review this?