### PR TITLE
Add hashtags to stats API response

### DIFF
--- a/api/queries.py
+++ b/api/queries.py
@@ -37,6 +37,18 @@ _TAG_CTES = """,
             GROUP BY uid
         )"""
 
+_HASHTAG_CTE = """,
+        user_hashtags AS (
+            SELECT
+                st.uid,
+                ARRAY_AGG(DISTINCT ht.hashtag ORDER BY ht.hashtag) AS hashtags
+            FROM stats_scope st
+            JOIN changesets cs ON cs.changeset_id = st.changeset_id
+            CROSS JOIN LATERAL UNNEST(cs.hashtags) AS ht(hashtag)
+            WHERE cs.hashtags IS NOT NULL
+            GROUP BY st.uid
+        )"""
+
 
 def _user_stats_sql(*, filter_dates: bool, filter_hashtags: bool, include_tags: bool) -> str:
     n = 1
@@ -76,7 +88,7 @@ def _user_stats_sql(*, filter_dates: bool, filter_hashtags: bool, include_tags: 
     tag_group = ", tpu.tag_stats" if include_tags else ""
 
     return f"""
-        {scope_cte}{tag_ctes}
+        {scope_cte}{_HASHTAG_CTE}{tag_ctes}
         SELECT
             u.uid,
             u.username AS name,
@@ -112,11 +124,13 @@ def _user_stats_sql(*, filter_dates: bool, filter_hashtags: bool, include_tags: 
                     ) DESC,
                     u.uid ASC
             ) AS rank,
+            COALESCE(uh.hashtags, ARRAY[]::TEXT[]) AS hashtags,
             {tag_select}
         FROM users u
         JOIN stats_scope st ON u.uid = st.uid
+        LEFT JOIN user_hashtags uh ON uh.uid = u.uid
         {tag_join}
-        GROUP BY u.uid, u.username{tag_group}
+        GROUP BY u.uid, u.username, uh.hashtags{tag_group}
         ORDER BY map_changes DESC, u.uid ASC
         LIMIT {limit_param} OFFSET {offset_param}
     """

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TagValueStats(BaseModel):
@@ -26,6 +26,7 @@ class UserStat(BaseModel):
     poi_modify: int
     map_changes: int
     rank: int
+    hashtags: list[str] = Field(default_factory=list)
     tag_stats: dict[str, dict[str, TagValueStats]] | None = None
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,6 +87,7 @@ def test_user_stats_endpoint_returns_expected_response(monkeypatch):
                 "poi_modify": 1,
                 "map_changes": 58,
                 "rank": 1,
+                "hashtags": ["#mapathon", "#roads"],
                 "tag_stats": {"building": {"yes": {"c": 3, "m": 0}}},
             }
         ]
@@ -130,6 +131,7 @@ def test_user_stats_endpoint_returns_expected_response(monkeypatch):
                 "poi_modify": 1,
                 "map_changes": 58,
                 "rank": 1,
+                "hashtags": ["#mapathon", "#roads"],
                 "tag_stats": {"building": {"yes": {"c": 3, "m": 0, "len": None}}},
             }
         ],
@@ -171,6 +173,7 @@ def test_user_stats_endpoint_tags_false_drops_tag_stats(monkeypatch):
                 "poi_modify": 0,
                 "map_changes": 0,
                 "rank": 1,
+                "hashtags": [],
                 "tag_stats": None,
             }
         ]
@@ -192,6 +195,7 @@ def test_user_stats_sql_omits_tag_ctes_when_tags_false():
     assert "tag_per_user" in sql_with
     assert "tag_per_user" not in sql_without
     assert "NULL::jsonb AS tag_stats" in sql_without
+    assert "user_hashtags" in sql_without
 
 
 def _seed_pg_via_to_psql(fresh_db, populated_db_factory, dsn):
@@ -268,6 +272,8 @@ def test_live_api_stats_default_returns_dicts_not_strings(live_api_client):
     assert body["count"] == 2
     by_name = {u["name"]: u for u in body["users"]}
     assert isinstance(by_name["alice"]["tag_stats"], dict)
+    assert by_name["alice"]["hashtags"] == ["#mapathon"]
+    assert by_name["bob"]["hashtags"] == []
     assert by_name["alice"]["tag_stats"]["building"]["yes"]["c"] == 5
     assert by_name["alice"]["tag_stats"]["building"]["yes"]["m"] == 1
     assert by_name["alice"]["tag_stats"]["highway"]["residential"]["len"] == 245.7
@@ -318,6 +324,7 @@ def test_live_api_stats_hashtag_filters_to_matching_changesets(live_api_client):
     assert body["hashtag"] == ["#mapathon"]
     names = {u["name"] for u in body["users"]}
     assert names == {"alice"}
+    assert body["users"][0]["hashtags"] == ["#mapathon"]
 
 
 @pytest.mark.network
@@ -448,6 +455,7 @@ def test_user_stats_sql_no_filter_skips_changesets_join():
     assert "filtered_changesets" not in sql
     assert "JOIN filtered_changesets" not in sql
     assert "stats_scope AS (SELECT * FROM changeset_stats)" in sql
+    assert "LEFT JOIN user_hashtags" in sql
 
 
 def test_user_stats_sql_filtered_uses_changesets_join():


### PR DESCRIPTION
## Summary

Adds per-user hashtag output to the existing `/api/v1/stats` endpoint.

The endpoint already supported filtering stats by hashtag. This change also returns a `hashtags` list for each user row so frontend clients can display which hashtags contributed to each mapper's stats.

## Changes

- Aggregates distinct hashtags per user from `changesets.hashtags`
- Adds `hashtags` to the `UserStat` response schema
- Keeps existing hashtag filtering behavior unchanged
- Updates API tests to assert hashtag output in stats responses

## Testing

- `uv run --group api pytest tests/test_api.py`
- `uv run --group api ruff check api tests/test_api.py`