### PR TITLE
fix(osmsg/handlers.py): --length silently produced no output unless the same key was also passed to --tags

### DIFF
--- a/osmsg/handlers.py
+++ b/osmsg/handlers.py
@@ -120,6 +120,8 @@ class ChangefileHandler(osmium.SimpleHandler):
         self.stubs: dict[int, Changeset] = {}
         self.stats: dict[int, ChangesetStats] = {}
 
+        self._tracked_keys = set(config.get("additional_tags") or ()) | set(config.get("length") or ())
+
     def _should_collect(self, uname: str, cs_id: int) -> bool:
         if self.valid_changesets is not None and cs_id not in self.valid_changesets:
             return False
@@ -176,8 +178,8 @@ class ChangefileHandler(osmium.SimpleHandler):
                 tv.add(action)
                 if length_m:
                     tv.add_length(length_m)
-        elif cfg["additional_tags"]:
-            for k in cfg["additional_tags"]:
+        elif self._tracked_keys:
+            for k in self._tracked_keys:
                 if k not in tags:
                     continue
                 v = tags[k]


### PR DESCRIPTION
## The bug

In the default mode (no `--all`, no `--keys`), `ChangefileHandler._accumulate` decided which tag keys to record stats for by checking `cfg["additional_tags"]` (i.e. `--tags`) only.

`--length` is documented as its own independent flag, but the code never consulted `cfg["length"]` when building that list. As a result, any key passed to `--length` that wasn't *also* repeated in `--tags` never got a `TagValueStat` written for it — no error, no warning, just an empty/zero result.

## The fix

Track the union of `--tags` and `--length` keys instead of just `--tags`.

The tracked keys are computed once in `__init__` as `self._tracked_keys`, rather than re-reading `cfg["additional_tags"]` for every element.

## Before

```bash
uv run osmsg --length highway --last day
```

`highway_len_m` comes back as `0` for every row.

`ChangefileHandler` never accumulated anything for `highway` because `--length` doesn't feed into `additional_tags`.

## After

The same command now correctly reports the summed length of created `highway=*` ways.

`--length` works independently and also correctly picks up keys that are in `--length` but not in `--tags` when both are passed together.

For example:

```bash
uv run osmsg --tags building --length highway --last day
```

Previously, `highway` was silently dropped because only keys from `--tags` were tracked. It is now correctly included.
